### PR TITLE
Fix iIlegal invocation of setTimeout/setInterval

### DIFF
--- a/lib/RepeatingJob.js
+++ b/lib/RepeatingJob.js
@@ -32,7 +32,7 @@ function RepeatingJob(task, options) {
 }
 
 RepeatingJob.prototype._executeImpl = function() {
-	return this._timer(this._taskFunctor, this._millis);
+	return this._timer.call(null, this._taskFunctor, this._millis);
 };
 
 RepeatingJob.prototype.cancel = function () {


### PR DESCRIPTION
For browser compatibility. Because apparently it's illegal to call setTimeout/Interval with a custom `this`.
