### PR TITLE
Repeating jobs: time lag avoidance

### DIFF
--- a/lib/RepeatingJob.js
+++ b/lib/RepeatingJob.js
@@ -25,14 +25,14 @@ function RepeatingJob(task, options) {
 	this._taskFunctor = function functor() {
 		self._taskFunctor = self._repeatingTaskFunctor;
 		self._timer = setInterval;
-		self._millis = self._options.interval;
+		self._millis = self._computeNextExecution; //SRSR self._options.interval;
 		self._task(self);
 		self.execute();
 	};
 }
 
 RepeatingJob.prototype._executeImpl = function() {
-	return this._timer.call(null, this._taskFunctor, this._millis);
+	return this._timer.call(null, this._taskFunctor, typeof this._millis === "function" ? this._millis() : this._millis);//SRSR this._millis);
 };
 
 RepeatingJob.prototype.cancel = function () {
@@ -40,3 +40,11 @@ RepeatingJob.prototype.cancel = function () {
 	clearTimeout(this._ref);
 	clearInterval(this._ref);
 };
+
+//SRSR intervall correction for next execution
+RepeatingJob.prototype._computeNextExecution = function() {
+	var now = Date.now();
+	var nextIntervall = (now + this._options.interval - ( (now - this._options.start) % this._options.interval )) - Date.now();
+	//console.log(`\t...next intervall duration: ${nextIntervall}\n\t   started at: ${this._options.start}\n\t   now: ${now}`);
+	return nextIntervall;
+}

--- a/lib/SeriallyRepeatingJob.js
+++ b/lib/SeriallyRepeatingJob.js
@@ -17,7 +17,7 @@ function SeriallyRepeatingJob(task, options) {
 
 	this._taskFunctor = function functor() {
 		self._taskFunctor = self._repeatingTaskFunctor;
-		self._millis = self._options.interval;
+		self._millis = self._computeNextExecution; //SRSR self._options.interval;
 		self._task(self);
 	};
 }

--- a/lib/scheduling.js
+++ b/lib/scheduling.js
@@ -69,6 +69,8 @@ module.exports = function schedule(intervalOrDate, task, options) {
 	}
 
 	opts.delay = start - now;
+	//SRSR keep starting point in time too
+	opts.start = start;
 
 	job = new Implementation(task, opts);
 


### PR DESCRIPTION
Hi Yaniv,

using tempus-fugit, I have set up a job, that repeats every 5 minutes, and I noticed a time lag of 20 second in an interval of 14 days. 
To avoid this, I'd propose to recalculate the waiting interval for the next iteration based on the starting point in time and planned interval between execution.

BR Stephan